### PR TITLE
feat(SyncedCron): add types for config and add.persist option + UI

### DIFF
--- a/SyncedCron/imports/ui/SyncedCron.tsx
+++ b/SyncedCron/imports/ui/SyncedCron.tsx
@@ -20,9 +20,14 @@ export function SyncedCron() {
       <fieldset>
         <legend>Add a job (log in server console)</legend>
         <Formik
-          initialValues={{ jobName: "", scheduleText: "" }}
+          initialValues={{ jobName: "", scheduleText: "", persist: true }}
           onSubmit={(values) =>
-            Meteor.call("syncedCronAdd", values.jobName, values.scheduleText)
+            Meteor.call(
+              "syncedCronAdd",
+              values.jobName,
+              values.scheduleText,
+              values.persist
+            )
           }
         >
           <Form>
@@ -36,6 +41,10 @@ export function SyncedCron() {
                 name="scheduleText"
                 placeholder="Schedule text expression..."
               />
+            </label>
+            <label>
+              Persist (log & sync)
+              <Field type="checkbox" name="persist" />
             </label>
             <button type="submit">Add</button>
           </Form>

--- a/SyncedCron/server/main.ts
+++ b/SyncedCron/server/main.ts
@@ -11,6 +11,8 @@
 
 /// <reference types="meteor-synced-cron" />
 
+import { SyncedCron } from "meteor/littledata:synced-cron";
+
 console.log("SyncedCron main server");
 
 // SyncedCron configuration

--- a/SyncedCron/server/main.ts
+++ b/SyncedCron/server/main.ts
@@ -12,3 +12,32 @@
 /// <reference types="meteor-synced-cron" />
 
 console.log("SyncedCron main server");
+
+// SyncedCron configuration
+// https://github.com/percolatestudio/meteor-synced-cron#configuration
+SyncedCron.config({
+  // Log job run details to console
+  log: true,
+
+  // Use a custom logger function (defaults to Meteor's logging package)
+  logger: null,
+
+  // Name of collection to use for synchronisation and logging
+  collectionName: "cronHistory",
+
+  // Default to using localTime
+  utc: false,
+
+  /*
+    TTL in seconds for history records in collection to expire
+    NOTE: Unset to remove expiry but ensure you remove the index from
+    mongo by hand
+
+    ALSO: SyncedCron can't use the `_ensureIndex` command to modify
+    the TTL index. The best way to modify the default value of
+    `collectionTTL` is to remove the index by hand (in the mongo shell
+    run `db.cronHistory.dropIndex({startedAt: 1})`) and re-run your
+    project. SyncedCron will recreate the index with the updated TTL.
+  */
+  collectionTTL: 172800,
+});

--- a/SyncedCron/server/methods.ts
+++ b/SyncedCron/server/methods.ts
@@ -4,7 +4,7 @@ import { Meteor } from "meteor/meteor";
 // SyncedCron can only be used server-side,
 // so the Methods implementation is also only on server
 Meteor.methods({
-  syncedCronAdd(jobName: string, scheduleText: string) {
+  syncedCronAdd(jobName: string, scheduleText: string, persist: boolean) {
     console.log(
       `SyncedCron add job name "${jobName}" with schedule text expression"${scheduleText}"`
     );
@@ -14,7 +14,7 @@ Meteor.methods({
         return parser.text(scheduleText);
       },
       job,
-      persist: true,
+      persist,
     });
   },
   syncedCronStart() {

--- a/SyncedCron/server/methods.ts
+++ b/SyncedCron/server/methods.ts
@@ -14,6 +14,7 @@ Meteor.methods({
         return parser.text(scheduleText);
       },
       job,
+      persist: true,
     });
   },
   syncedCronStart() {

--- a/types/meteor-synced-cron.d.ts
+++ b/types/meteor-synced-cron.d.ts
@@ -9,5 +9,84 @@
 declare module 'meteor/littledata:synced-cron' {
     namespace SyncedCron {
         // Add types for development here
+
+        /**
+         * You can configure SyncedCron with the `config` method.
+         *
+         * https://github.com/percolatestudio/meteor-synced-cron#configuration
+         */
+        function config(opts: {
+            /**
+             * Log job run details to console
+             *
+             * Default `true`
+             */
+            log?: boolean;
+
+            /**
+             * Use a custom logger function (defaults to Meteor's logging package)
+             *
+             * SyncedCron uses Meteor's `logging` package by default.
+             * If you want to use your own logger (for sending to other consumers or similar)
+             * you can do so by configuring the `logger` option.
+             *
+             * SyncedCron expects a function as `logger`,
+             * and will pass arguments to it for you to take action on.
+             *
+             * The `opts` passed argument includes `level`, `message`, and `tag`.
+             * - `level` will be one of `"info"`, `"warn"`, `"error"`, `"debug"`.
+             * - `message` is something like `'Scheduled "Test Job" next run @Fri Mar 13 2015 10:15:00 GMT+0100 (CET)'`".
+             * - `tag` will always be `"SyncedCron"` (handy for filtering).
+             *
+             * https://github.com/percolatestudio/meteor-synced-cron#logging
+             */
+            logger?:
+                | ((opts: {
+                      /**
+                       * will be one of `"info"`, `"warn"`, `"error"`, `"debug"`.
+                       */
+                      level: 'info' | 'warn' | 'error' | 'debug';
+                      /**
+                       * something like `'Scheduled "Test Job" next run @Fri Mar 13 2015 10:15:00 GMT+0100 (CET)'`".
+                       */
+                      message: string;
+                      /**
+                       * will always be `"SyncedCron"` (handy for filtering).
+                       */
+                      tag: string;
+                  }) => void)
+                | null;
+
+            /**
+             * Name of collection to use for synchronisation and logging
+             *
+             * Default `"cronHistory"`
+             */
+            collectionName?: string;
+
+            /**
+             * Use UTC or localtime for evaluating schedules
+             *
+             * Default to using localTime
+             *
+             * Default `false`
+             */
+            utc?: boolean;
+
+            /**
+             * TTL in seconds for history records in collection to expire
+             * NOTE: Unset to remove expiry but ensure you remove the index from
+             * mongo by hand
+             *
+             * ALSO: SyncedCron can't use the `_ensureIndex` command to modify
+             * the TTL index. The best way to modify the default value of
+             * `collectionTTL` is to remove the index by hand (in the mongo shell
+             * run `db.cronHistory.dropIndex({startedAt: 1})`) and re-run your
+             * project. SyncedCron will recreate the index with the updated TTL.
+             *
+             * Default `172800` seconds (48 hours)
+             */
+            collectionTTL?: number;
+        }): void;
     }
 }

--- a/types/meteor-synced-cron.d.ts
+++ b/types/meteor-synced-cron.d.ts
@@ -10,6 +10,33 @@ declare module 'meteor/littledata:synced-cron' {
     namespace SyncedCron {
         // Add types for development here
 
+        function add(addOptions: {
+            /**
+             * *required* unique name of the job
+             */
+            name: string;
+            /**
+             * *required* when to run the job
+             *
+             * @param parser is a later.parse object
+             */
+            schedule: (parser: later.ParseStatic) => later.ScheduleData;
+            /**
+             * *required* the code to run
+             */
+            job: () => void;
+
+            /**
+             * Undocumented flag to enable synchronization and logging
+             * for this job
+             *
+             * Default `true`
+             *
+             * https://github.com/percolatestudio/meteor-synced-cron/blob/687e9ea308a287fe6347f94e0fb3eac5e2e21c12/synced-cron-server.js#L120-L124
+             */
+            persist?: boolean;
+        }): void;
+
         /**
          * You can configure SyncedCron with the `config` method.
          *


### PR DESCRIPTION
Improve type definition of littledata:synced-cron package with:
- [Configuration](https://github.com/percolatestudio/meteor-synced-cron#configuration): `SyncedCron.config()` (no UI, because the configuration is only picked up at `Meteor.startup`)
- [Undocumented `persist` option](https://github.com/percolatestudio/meteor-synced-cron/blob/687e9ea308a287fe6347f94e0fb3eac5e2e21c12/synced-cron-server.js#L120-L124) of `SyncedCron.add()` + UI